### PR TITLE
Change pyside.org to pyside.github.io

### DIFF
--- a/docs/api-extractor/contents.html
+++ b/docs/api-extractor/contents.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li> 

--- a/docs/api-extractor/html/contents.html
+++ b/docs/api-extractor/html/contents.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li> 

--- a/docs/api-extractor/html/index.html
+++ b/docs/api-extractor/html/index.html
@@ -30,7 +30,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="#">API Extractor  documentation</a></li> 

--- a/docs/api-extractor/html/overview.html
+++ b/docs/api-extractor/html/overview.html
@@ -33,7 +33,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li> 

--- a/docs/api-extractor/html/ownership.html
+++ b/docs/api-extractor/html/ownership.html
@@ -33,7 +33,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li> 

--- a/docs/api-extractor/html/search.html
+++ b/docs/api-extractor/html/search.html
@@ -37,7 +37,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li> 

--- a/docs/api-extractor/html/typesystem.html
+++ b/docs/api-extractor/html/typesystem.html
@@ -33,7 +33,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li> 

--- a/docs/api-extractor/html/typesystem_arguments.html
+++ b/docs/api-extractor/html/typesystem_arguments.html
@@ -34,7 +34,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li>

--- a/docs/api-extractor/html/typesystem_conversionrule.html
+++ b/docs/api-extractor/html/typesystem_conversionrule.html
@@ -34,7 +34,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li>

--- a/docs/api-extractor/html/typesystem_documentation.html
+++ b/docs/api-extractor/html/typesystem_documentation.html
@@ -33,7 +33,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li>

--- a/docs/api-extractor/html/typesystem_manipulating_objects.html
+++ b/docs/api-extractor/html/typesystem_manipulating_objects.html
@@ -34,7 +34,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li>

--- a/docs/api-extractor/html/typesystem_modify_function.html
+++ b/docs/api-extractor/html/typesystem_modify_function.html
@@ -34,7 +34,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li>

--- a/docs/api-extractor/html/typesystem_solving_compilation.html
+++ b/docs/api-extractor/html/typesystem_solving_compilation.html
@@ -34,7 +34,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li>

--- a/docs/api-extractor/html/typesystem_specifying_types.html
+++ b/docs/api-extractor/html/typesystem_specifying_types.html
@@ -34,7 +34,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li>

--- a/docs/api-extractor/html/typesystem_templates.html
+++ b/docs/api-extractor/html/typesystem_templates.html
@@ -34,7 +34,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li>

--- a/docs/api-extractor/index.html
+++ b/docs/api-extractor/index.html
@@ -30,7 +30,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="#">API Extractor  documentation</a></li> 

--- a/docs/api-extractor/overview.html
+++ b/docs/api-extractor/overview.html
@@ -33,7 +33,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li> 

--- a/docs/api-extractor/ownership.html
+++ b/docs/api-extractor/ownership.html
@@ -33,7 +33,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li> 

--- a/docs/api-extractor/search.html
+++ b/docs/api-extractor/search.html
@@ -37,7 +37,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li> 

--- a/docs/api-extractor/typesystem.html
+++ b/docs/api-extractor/typesystem.html
@@ -33,7 +33,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li> 

--- a/docs/api-extractor/typesystem_arguments.html
+++ b/docs/api-extractor/typesystem_arguments.html
@@ -34,7 +34,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li>

--- a/docs/api-extractor/typesystem_conversionrule.html
+++ b/docs/api-extractor/typesystem_conversionrule.html
@@ -34,7 +34,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li>

--- a/docs/api-extractor/typesystem_documentation.html
+++ b/docs/api-extractor/typesystem_documentation.html
@@ -33,7 +33,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li>

--- a/docs/api-extractor/typesystem_manipulating_objects.html
+++ b/docs/api-extractor/typesystem_manipulating_objects.html
@@ -34,7 +34,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li>

--- a/docs/api-extractor/typesystem_modify_function.html
+++ b/docs/api-extractor/typesystem_modify_function.html
@@ -34,7 +34,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li>

--- a/docs/api-extractor/typesystem_solving_compilation.html
+++ b/docs/api-extractor/typesystem_solving_compilation.html
@@ -34,7 +34,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li>

--- a/docs/api-extractor/typesystem_specifying_types.html
+++ b/docs/api-extractor/typesystem_specifying_types.html
@@ -34,7 +34,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li>

--- a/docs/api-extractor/typesystem_templates.html
+++ b/docs/api-extractor/typesystem_templates.html
@@ -34,7 +34,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">API Extractor  documentation</a></li>

--- a/docs/pyside/PySide/QtCore/ClassInfo.html
+++ b/docs/pyside/PySide/QtCore/ClassInfo.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>
@@ -87,7 +87,7 @@ using QObject.metaObject(). Qt and PySide doesn&#8217;t use this information.</p
 </div>
 <div class="section" id="example">
 <h2>Example<a class="headerlink" href="#example" title="Permalink to this headline">¶</a></h2>
-<div class="highlight-python"><div class="highlight"><pre><span class="nd">@ClassInfo</span><span class="p">(</span><span class="n">Author</span><span class="o">=</span><span class="s">&#39;PySide Team&#39;</span><span class="p">,</span> <span class="n">URL</span><span class="o">=</span><span class="s">&#39;http://www.pyside.org&#39;</span><span class="p">)</span>
+<div class="highlight-python"><div class="highlight"><pre><span class="nd">@ClassInfo</span><span class="p">(</span><span class="n">Author</span><span class="o">=</span><span class="s">&#39;PySide Team&#39;</span><span class="p">,</span> <span class="n">URL</span><span class="o">=</span><span class="s">&#39;https://pyside.github.io&#39;</span><span class="p">)</span>
 <span class="k">class</span> <span class="nc">MyObject</span><span class="p">(</span><span class="n">QObject</span><span class="p">):</span>
     <span class="o">...</span>
 </pre></div>

--- a/docs/pyside/PySide/QtCore/QAbstractAnimation.html
+++ b/docs/pyside/PySide/QtCore/QAbstractAnimation.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QAbstractEventDispatcher.html
+++ b/docs/pyside/PySide/QtCore/QAbstractEventDispatcher.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QAbstractFileEngine.html
+++ b/docs/pyside/PySide/QtCore/QAbstractFileEngine.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QAbstractFileEngineHandler.html
+++ b/docs/pyside/PySide/QtCore/QAbstractFileEngineHandler.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QAbstractFileEngineIterator.html
+++ b/docs/pyside/PySide/QtCore/QAbstractFileEngineIterator.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QAbstractItemModel.html
+++ b/docs/pyside/PySide/QtCore/QAbstractItemModel.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QAbstractListModel.html
+++ b/docs/pyside/PySide/QtCore/QAbstractListModel.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QAbstractState.html
+++ b/docs/pyside/PySide/QtCore/QAbstractState.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QAbstractTableModel.html
+++ b/docs/pyside/PySide/QtCore/QAbstractTableModel.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QAbstractTransition.html
+++ b/docs/pyside/PySide/QtCore/QAbstractTransition.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QAnimationGroup.html
+++ b/docs/pyside/PySide/QtCore/QAnimationGroup.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QBasicTimer.html
+++ b/docs/pyside/PySide/QtCore/QBasicTimer.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QBitArray.html
+++ b/docs/pyside/PySide/QtCore/QBitArray.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QBuffer.html
+++ b/docs/pyside/PySide/QtCore/QBuffer.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QByteArray.html
+++ b/docs/pyside/PySide/QtCore/QByteArray.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QByteArrayMatcher.html
+++ b/docs/pyside/PySide/QtCore/QByteArrayMatcher.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QChildEvent.html
+++ b/docs/pyside/PySide/QtCore/QChildEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QCoreApplication.html
+++ b/docs/pyside/PySide/QtCore/QCoreApplication.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QCryptographicHash.html
+++ b/docs/pyside/PySide/QtCore/QCryptographicHash.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QDataStream.html
+++ b/docs/pyside/PySide/QtCore/QDataStream.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QDate.html
+++ b/docs/pyside/PySide/QtCore/QDate.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QDateTime.html
+++ b/docs/pyside/PySide/QtCore/QDateTime.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QDir.html
+++ b/docs/pyside/PySide/QtCore/QDir.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QDirIterator.html
+++ b/docs/pyside/PySide/QtCore/QDirIterator.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QDynamicPropertyChangeEvent.html
+++ b/docs/pyside/PySide/QtCore/QDynamicPropertyChangeEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QEasingCurve.html
+++ b/docs/pyside/PySide/QtCore/QEasingCurve.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QElapsedTimer.html
+++ b/docs/pyside/PySide/QtCore/QElapsedTimer.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QEvent.html
+++ b/docs/pyside/PySide/QtCore/QEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QEventLoop.html
+++ b/docs/pyside/PySide/QtCore/QEventLoop.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QEventTransition.html
+++ b/docs/pyside/PySide/QtCore/QEventTransition.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QFSFileEngine.html
+++ b/docs/pyside/PySide/QtCore/QFSFileEngine.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QFactoryInterface.html
+++ b/docs/pyside/PySide/QtCore/QFactoryInterface.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QFile.html
+++ b/docs/pyside/PySide/QtCore/QFile.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QFileInfo.html
+++ b/docs/pyside/PySide/QtCore/QFileInfo.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QFileSystemWatcher.html
+++ b/docs/pyside/PySide/QtCore/QFileSystemWatcher.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QFinalState.html
+++ b/docs/pyside/PySide/QtCore/QFinalState.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QGenericArgument.html
+++ b/docs/pyside/PySide/QtCore/QGenericArgument.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QGenericReturnArgument.html
+++ b/docs/pyside/PySide/QtCore/QGenericReturnArgument.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QHistoryState.html
+++ b/docs/pyside/PySide/QtCore/QHistoryState.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QIODevice.html
+++ b/docs/pyside/PySide/QtCore/QIODevice.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QLibraryInfo.html
+++ b/docs/pyside/PySide/QtCore/QLibraryInfo.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QLine.html
+++ b/docs/pyside/PySide/QtCore/QLine.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QLineF.html
+++ b/docs/pyside/PySide/QtCore/QLineF.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QLocale.html
+++ b/docs/pyside/PySide/QtCore/QLocale.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QMargins.html
+++ b/docs/pyside/PySide/QtCore/QMargins.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QMetaClassInfo.html
+++ b/docs/pyside/PySide/QtCore/QMetaClassInfo.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QMetaEnum.html
+++ b/docs/pyside/PySide/QtCore/QMetaEnum.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QMetaMethod.html
+++ b/docs/pyside/PySide/QtCore/QMetaMethod.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QMetaObject.html
+++ b/docs/pyside/PySide/QtCore/QMetaObject.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QMetaProperty.html
+++ b/docs/pyside/PySide/QtCore/QMetaProperty.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QMimeData.html
+++ b/docs/pyside/PySide/QtCore/QMimeData.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QModelIndex.html
+++ b/docs/pyside/PySide/QtCore/QModelIndex.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QMutex.html
+++ b/docs/pyside/PySide/QtCore/QMutex.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QMutexLocker.html
+++ b/docs/pyside/PySide/QtCore/QMutexLocker.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QObject.html
+++ b/docs/pyside/PySide/QtCore/QObject.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QParallelAnimationGroup.html
+++ b/docs/pyside/PySide/QtCore/QParallelAnimationGroup.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QPauseAnimation.html
+++ b/docs/pyside/PySide/QtCore/QPauseAnimation.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QPersistentModelIndex.html
+++ b/docs/pyside/PySide/QtCore/QPersistentModelIndex.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QPluginLoader.html
+++ b/docs/pyside/PySide/QtCore/QPluginLoader.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QPoint.html
+++ b/docs/pyside/PySide/QtCore/QPoint.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QPointF.html
+++ b/docs/pyside/PySide/QtCore/QPointF.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QProcess.html
+++ b/docs/pyside/PySide/QtCore/QProcess.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QProcessEnvironment.html
+++ b/docs/pyside/PySide/QtCore/QProcessEnvironment.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QPropertyAnimation.html
+++ b/docs/pyside/PySide/QtCore/QPropertyAnimation.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QReadLocker.html
+++ b/docs/pyside/PySide/QtCore/QReadLocker.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QReadWriteLock.html
+++ b/docs/pyside/PySide/QtCore/QReadWriteLock.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QRect.html
+++ b/docs/pyside/PySide/QtCore/QRect.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QRectF.html
+++ b/docs/pyside/PySide/QtCore/QRectF.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QRegExp.html
+++ b/docs/pyside/PySide/QtCore/QRegExp.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QResource.html
+++ b/docs/pyside/PySide/QtCore/QResource.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QRunnable.html
+++ b/docs/pyside/PySide/QtCore/QRunnable.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QSemaphore.html
+++ b/docs/pyside/PySide/QtCore/QSemaphore.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QSequentialAnimationGroup.html
+++ b/docs/pyside/PySide/QtCore/QSequentialAnimationGroup.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QSettings.html
+++ b/docs/pyside/PySide/QtCore/QSettings.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QSignalMapper.html
+++ b/docs/pyside/PySide/QtCore/QSignalMapper.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QSignalTransition.html
+++ b/docs/pyside/PySide/QtCore/QSignalTransition.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QSize.html
+++ b/docs/pyside/PySide/QtCore/QSize.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QSizeF.html
+++ b/docs/pyside/PySide/QtCore/QSizeF.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QSocketNotifier.html
+++ b/docs/pyside/PySide/QtCore/QSocketNotifier.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QState.html
+++ b/docs/pyside/PySide/QtCore/QState.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QStateMachine.SignalEvent.html
+++ b/docs/pyside/PySide/QtCore/QStateMachine.SignalEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QStateMachine.WrappedEvent.html
+++ b/docs/pyside/PySide/QtCore/QStateMachine.WrappedEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QStateMachine.html
+++ b/docs/pyside/PySide/QtCore/QStateMachine.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QSysInfo.html
+++ b/docs/pyside/PySide/QtCore/QSysInfo.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QSystemLocale.html
+++ b/docs/pyside/PySide/QtCore/QSystemLocale.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QSystemSemaphore.html
+++ b/docs/pyside/PySide/QtCore/QSystemSemaphore.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QTemporaryFile.html
+++ b/docs/pyside/PySide/QtCore/QTemporaryFile.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QTextBoundaryFinder.html
+++ b/docs/pyside/PySide/QtCore/QTextBoundaryFinder.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QTextCodec.ConverterState.html
+++ b/docs/pyside/PySide/QtCore/QTextCodec.ConverterState.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QTextCodec.html
+++ b/docs/pyside/PySide/QtCore/QTextCodec.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QTextDecoder.html
+++ b/docs/pyside/PySide/QtCore/QTextDecoder.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QTextEncoder.html
+++ b/docs/pyside/PySide/QtCore/QTextEncoder.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QTextStream.html
+++ b/docs/pyside/PySide/QtCore/QTextStream.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QTextStreamManipulator.html
+++ b/docs/pyside/PySide/QtCore/QTextStreamManipulator.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QThread.html
+++ b/docs/pyside/PySide/QtCore/QThread.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QThreadPool.html
+++ b/docs/pyside/PySide/QtCore/QThreadPool.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QTime.html
+++ b/docs/pyside/PySide/QtCore/QTime.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QTimeLine.html
+++ b/docs/pyside/PySide/QtCore/QTimeLine.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QTimer.html
+++ b/docs/pyside/PySide/QtCore/QTimer.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QTimerEvent.html
+++ b/docs/pyside/PySide/QtCore/QTimerEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QTranslator.html
+++ b/docs/pyside/PySide/QtCore/QTranslator.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QUrl.html
+++ b/docs/pyside/PySide/QtCore/QUrl.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QUuid.html
+++ b/docs/pyside/PySide/QtCore/QUuid.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QVariantAnimation.html
+++ b/docs/pyside/PySide/QtCore/QVariantAnimation.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QWaitCondition.html
+++ b/docs/pyside/PySide/QtCore/QWaitCondition.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QWriteLocker.html
+++ b/docs/pyside/PySide/QtCore/QWriteLocker.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QXmlStreamAttribute.html
+++ b/docs/pyside/PySide/QtCore/QXmlStreamAttribute.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QXmlStreamAttributes.html
+++ b/docs/pyside/PySide/QtCore/QXmlStreamAttributes.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QXmlStreamEntityDeclaration.html
+++ b/docs/pyside/PySide/QtCore/QXmlStreamEntityDeclaration.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QXmlStreamEntityResolver.html
+++ b/docs/pyside/PySide/QtCore/QXmlStreamEntityResolver.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QXmlStreamNamespaceDeclaration.html
+++ b/docs/pyside/PySide/QtCore/QXmlStreamNamespaceDeclaration.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QXmlStreamNotationDeclaration.html
+++ b/docs/pyside/PySide/QtCore/QXmlStreamNotationDeclaration.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QXmlStreamReader.html
+++ b/docs/pyside/PySide/QtCore/QXmlStreamReader.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QXmlStreamWriter.html
+++ b/docs/pyside/PySide/QtCore/QXmlStreamWriter.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/Qt.html
+++ b/docs/pyside/PySide/QtCore/Qt.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/QtConcurrent.html
+++ b/docs/pyside/PySide/QtCore/QtConcurrent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/Signal.html
+++ b/docs/pyside/PySide/QtCore/Signal.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/Slot.html
+++ b/docs/pyside/PySide/QtCore/Slot.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtCore/index.html
+++ b/docs/pyside/PySide/QtCore/index.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtDeclarative/ListProperty.html
+++ b/docs/pyside/PySide/QtDeclarative/ListProperty.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtDeclarative/QDeclarativeComponent.html
+++ b/docs/pyside/PySide/QtDeclarative/QDeclarativeComponent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtDeclarative/QDeclarativeContext.html
+++ b/docs/pyside/PySide/QtDeclarative/QDeclarativeContext.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtDeclarative/QDeclarativeEngine.html
+++ b/docs/pyside/PySide/QtDeclarative/QDeclarativeEngine.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtDeclarative/QDeclarativeError.html
+++ b/docs/pyside/PySide/QtDeclarative/QDeclarativeError.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtDeclarative/QDeclarativeExpression.html
+++ b/docs/pyside/PySide/QtDeclarative/QDeclarativeExpression.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtDeclarative/QDeclarativeExtensionInterface.html
+++ b/docs/pyside/PySide/QtDeclarative/QDeclarativeExtensionInterface.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtDeclarative/QDeclarativeExtensionPlugin.html
+++ b/docs/pyside/PySide/QtDeclarative/QDeclarativeExtensionPlugin.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtDeclarative/QDeclarativeImageProvider.html
+++ b/docs/pyside/PySide/QtDeclarative/QDeclarativeImageProvider.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtDeclarative/QDeclarativeItem.html
+++ b/docs/pyside/PySide/QtDeclarative/QDeclarativeItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtDeclarative/QDeclarativeListReference.html
+++ b/docs/pyside/PySide/QtDeclarative/QDeclarativeListReference.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtDeclarative/QDeclarativeNetworkAccessManagerFactory.html
+++ b/docs/pyside/PySide/QtDeclarative/QDeclarativeNetworkAccessManagerFactory.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtDeclarative/QDeclarativeParserStatus.html
+++ b/docs/pyside/PySide/QtDeclarative/QDeclarativeParserStatus.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtDeclarative/QDeclarativeProperty.html
+++ b/docs/pyside/PySide/QtDeclarative/QDeclarativeProperty.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtDeclarative/QDeclarativePropertyMap.html
+++ b/docs/pyside/PySide/QtDeclarative/QDeclarativePropertyMap.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtDeclarative/QDeclarativePropertyValueSource.html
+++ b/docs/pyside/PySide/QtDeclarative/QDeclarativePropertyValueSource.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtDeclarative/QDeclarativeScriptString.html
+++ b/docs/pyside/PySide/QtDeclarative/QDeclarativeScriptString.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtDeclarative/QDeclarativeView.html
+++ b/docs/pyside/PySide/QtDeclarative/QDeclarativeView.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtDeclarative/index.html
+++ b/docs/pyside/PySide/QtDeclarative/index.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QAbstractButton.html
+++ b/docs/pyside/PySide/QtGui/QAbstractButton.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QAbstractGraphicsShapeItem.html
+++ b/docs/pyside/PySide/QtGui/QAbstractGraphicsShapeItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QAbstractItemDelegate.html
+++ b/docs/pyside/PySide/QtGui/QAbstractItemDelegate.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QAbstractItemView.html
+++ b/docs/pyside/PySide/QtGui/QAbstractItemView.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QAbstractPageSetupDialog.html
+++ b/docs/pyside/PySide/QtGui/QAbstractPageSetupDialog.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QAbstractPrintDialog.html
+++ b/docs/pyside/PySide/QtGui/QAbstractPrintDialog.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QAbstractProxyModel.html
+++ b/docs/pyside/PySide/QtGui/QAbstractProxyModel.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QAbstractScrollArea.html
+++ b/docs/pyside/PySide/QtGui/QAbstractScrollArea.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QAbstractSlider.html
+++ b/docs/pyside/PySide/QtGui/QAbstractSlider.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QAbstractSpinBox.html
+++ b/docs/pyside/PySide/QtGui/QAbstractSpinBox.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QAbstractTextDocumentLayout.PaintContext.html
+++ b/docs/pyside/PySide/QtGui/QAbstractTextDocumentLayout.PaintContext.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QAbstractTextDocumentLayout.Selection.html
+++ b/docs/pyside/PySide/QtGui/QAbstractTextDocumentLayout.Selection.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QAbstractTextDocumentLayout.html
+++ b/docs/pyside/PySide/QtGui/QAbstractTextDocumentLayout.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QAccessibleEvent.html
+++ b/docs/pyside/PySide/QtGui/QAccessibleEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QAction.html
+++ b/docs/pyside/PySide/QtGui/QAction.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QActionEvent.html
+++ b/docs/pyside/PySide/QtGui/QActionEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QActionGroup.html
+++ b/docs/pyside/PySide/QtGui/QActionGroup.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QApplication.html
+++ b/docs/pyside/PySide/QtGui/QApplication.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QBitmap.html
+++ b/docs/pyside/PySide/QtGui/QBitmap.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QBoxLayout.html
+++ b/docs/pyside/PySide/QtGui/QBoxLayout.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QBrush.html
+++ b/docs/pyside/PySide/QtGui/QBrush.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QButtonGroup.html
+++ b/docs/pyside/PySide/QtGui/QButtonGroup.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QCDEStyle.html
+++ b/docs/pyside/PySide/QtGui/QCDEStyle.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QCalendarWidget.html
+++ b/docs/pyside/PySide/QtGui/QCalendarWidget.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QCheckBox.html
+++ b/docs/pyside/PySide/QtGui/QCheckBox.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QCleanlooksStyle.html
+++ b/docs/pyside/PySide/QtGui/QCleanlooksStyle.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QClipboard.html
+++ b/docs/pyside/PySide/QtGui/QClipboard.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QClipboardEvent.html
+++ b/docs/pyside/PySide/QtGui/QClipboardEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QCloseEvent.html
+++ b/docs/pyside/PySide/QtGui/QCloseEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QColor.html
+++ b/docs/pyside/PySide/QtGui/QColor.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QColorDialog.html
+++ b/docs/pyside/PySide/QtGui/QColorDialog.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QColumnView.html
+++ b/docs/pyside/PySide/QtGui/QColumnView.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QComboBox.html
+++ b/docs/pyside/PySide/QtGui/QComboBox.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QCommandLinkButton.html
+++ b/docs/pyside/PySide/QtGui/QCommandLinkButton.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QCommonStyle.html
+++ b/docs/pyside/PySide/QtGui/QCommonStyle.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QCompleter.html
+++ b/docs/pyside/PySide/QtGui/QCompleter.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QConicalGradient.html
+++ b/docs/pyside/PySide/QtGui/QConicalGradient.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QContextMenuEvent.html
+++ b/docs/pyside/PySide/QtGui/QContextMenuEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QCursor.html
+++ b/docs/pyside/PySide/QtGui/QCursor.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QDataWidgetMapper.html
+++ b/docs/pyside/PySide/QtGui/QDataWidgetMapper.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QDateEdit.html
+++ b/docs/pyside/PySide/QtGui/QDateEdit.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QDateTimeEdit.html
+++ b/docs/pyside/PySide/QtGui/QDateTimeEdit.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QDesktopServices.html
+++ b/docs/pyside/PySide/QtGui/QDesktopServices.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QDesktopWidget.html
+++ b/docs/pyside/PySide/QtGui/QDesktopWidget.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QDial.html
+++ b/docs/pyside/PySide/QtGui/QDial.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QDialog.html
+++ b/docs/pyside/PySide/QtGui/QDialog.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QDialogButtonBox.html
+++ b/docs/pyside/PySide/QtGui/QDialogButtonBox.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QDirModel.html
+++ b/docs/pyside/PySide/QtGui/QDirModel.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QDockWidget.html
+++ b/docs/pyside/PySide/QtGui/QDockWidget.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QDoubleSpinBox.html
+++ b/docs/pyside/PySide/QtGui/QDoubleSpinBox.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QDoubleValidator.html
+++ b/docs/pyside/PySide/QtGui/QDoubleValidator.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QDrag.html
+++ b/docs/pyside/PySide/QtGui/QDrag.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QDragEnterEvent.html
+++ b/docs/pyside/PySide/QtGui/QDragEnterEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QDragLeaveEvent.html
+++ b/docs/pyside/PySide/QtGui/QDragLeaveEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QDragMoveEvent.html
+++ b/docs/pyside/PySide/QtGui/QDragMoveEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QDropEvent.html
+++ b/docs/pyside/PySide/QtGui/QDropEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QErrorMessage.html
+++ b/docs/pyside/PySide/QtGui/QErrorMessage.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QFileDialog.html
+++ b/docs/pyside/PySide/QtGui/QFileDialog.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QFileIconProvider.html
+++ b/docs/pyside/PySide/QtGui/QFileIconProvider.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QFileOpenEvent.html
+++ b/docs/pyside/PySide/QtGui/QFileOpenEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QFileSystemModel.html
+++ b/docs/pyside/PySide/QtGui/QFileSystemModel.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QFocusEvent.html
+++ b/docs/pyside/PySide/QtGui/QFocusEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QFocusFrame.html
+++ b/docs/pyside/PySide/QtGui/QFocusFrame.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QFont.html
+++ b/docs/pyside/PySide/QtGui/QFont.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QFontComboBox.html
+++ b/docs/pyside/PySide/QtGui/QFontComboBox.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QFontDatabase.html
+++ b/docs/pyside/PySide/QtGui/QFontDatabase.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QFontDialog.html
+++ b/docs/pyside/PySide/QtGui/QFontDialog.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QFontInfo.html
+++ b/docs/pyside/PySide/QtGui/QFontInfo.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QFontMetrics.html
+++ b/docs/pyside/PySide/QtGui/QFontMetrics.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QFontMetricsF.html
+++ b/docs/pyside/PySide/QtGui/QFontMetricsF.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QFormLayout.html
+++ b/docs/pyside/PySide/QtGui/QFormLayout.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QFrame.html
+++ b/docs/pyside/PySide/QtGui/QFrame.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGesture.html
+++ b/docs/pyside/PySide/QtGui/QGesture.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGestureEvent.html
+++ b/docs/pyside/PySide/QtGui/QGestureEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGestureRecognizer.html
+++ b/docs/pyside/PySide/QtGui/QGestureRecognizer.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGradient.html
+++ b/docs/pyside/PySide/QtGui/QGradient.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsAnchor.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsAnchor.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsAnchorLayout.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsAnchorLayout.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsBlurEffect.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsBlurEffect.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsColorizeEffect.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsColorizeEffect.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsDropShadowEffect.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsDropShadowEffect.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsEffect.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsEffect.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsEllipseItem.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsEllipseItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsGridLayout.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsGridLayout.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsItem.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsItemAnimation.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsItemAnimation.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsItemGroup.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsItemGroup.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsLayout.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsLayout.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsLayoutItem.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsLayoutItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsLineItem.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsLineItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsLinearLayout.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsLinearLayout.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsObject.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsObject.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsOpacityEffect.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsOpacityEffect.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsPathItem.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsPathItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsPixmapItem.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsPixmapItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsPolygonItem.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsPolygonItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsProxyWidget.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsProxyWidget.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsRectItem.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsRectItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsRotation.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsRotation.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsScale.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsScale.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsScene.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsScene.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsSceneContextMenuEvent.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsSceneContextMenuEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsSceneDragDropEvent.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsSceneDragDropEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsSceneEvent.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsSceneEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsSceneHelpEvent.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsSceneHelpEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsSceneHoverEvent.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsSceneHoverEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsSceneMouseEvent.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsSceneMouseEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsSceneMoveEvent.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsSceneMoveEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsSceneResizeEvent.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsSceneResizeEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsSceneWheelEvent.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsSceneWheelEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsSimpleTextItem.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsSimpleTextItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsTextItem.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsTextItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsTransform.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsTransform.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsView.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsView.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGraphicsWidget.html
+++ b/docs/pyside/PySide/QtGui/QGraphicsWidget.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGridLayout.html
+++ b/docs/pyside/PySide/QtGui/QGridLayout.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGroupBox.html
+++ b/docs/pyside/PySide/QtGui/QGroupBox.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QGtkStyle.html
+++ b/docs/pyside/PySide/QtGui/QGtkStyle.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QHBoxLayout.html
+++ b/docs/pyside/PySide/QtGui/QHBoxLayout.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QHeaderView.html
+++ b/docs/pyside/PySide/QtGui/QHeaderView.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QHelpEvent.html
+++ b/docs/pyside/PySide/QtGui/QHelpEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QHideEvent.html
+++ b/docs/pyside/PySide/QtGui/QHideEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QHoverEvent.html
+++ b/docs/pyside/PySide/QtGui/QHoverEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QIcon.html
+++ b/docs/pyside/PySide/QtGui/QIcon.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QIconDragEvent.html
+++ b/docs/pyside/PySide/QtGui/QIconDragEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QIconEngine.html
+++ b/docs/pyside/PySide/QtGui/QIconEngine.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QIconEngineV2.html
+++ b/docs/pyside/PySide/QtGui/QIconEngineV2.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QImage.html
+++ b/docs/pyside/PySide/QtGui/QImage.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QImageIOHandler.html
+++ b/docs/pyside/PySide/QtGui/QImageIOHandler.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QImageReader.html
+++ b/docs/pyside/PySide/QtGui/QImageReader.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QImageWriter.html
+++ b/docs/pyside/PySide/QtGui/QImageWriter.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QInputContext.html
+++ b/docs/pyside/PySide/QtGui/QInputContext.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QInputContextFactory.html
+++ b/docs/pyside/PySide/QtGui/QInputContextFactory.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QInputDialog.html
+++ b/docs/pyside/PySide/QtGui/QInputDialog.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QInputEvent.html
+++ b/docs/pyside/PySide/QtGui/QInputEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QInputMethodEvent.Attribute.html
+++ b/docs/pyside/PySide/QtGui/QInputMethodEvent.Attribute.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QInputMethodEvent.html
+++ b/docs/pyside/PySide/QtGui/QInputMethodEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QIntValidator.html
+++ b/docs/pyside/PySide/QtGui/QIntValidator.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QItemDelegate.html
+++ b/docs/pyside/PySide/QtGui/QItemDelegate.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QItemEditorCreatorBase.html
+++ b/docs/pyside/PySide/QtGui/QItemEditorCreatorBase.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QItemEditorFactory.html
+++ b/docs/pyside/PySide/QtGui/QItemEditorFactory.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QItemSelection.html
+++ b/docs/pyside/PySide/QtGui/QItemSelection.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QItemSelectionModel.html
+++ b/docs/pyside/PySide/QtGui/QItemSelectionModel.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QItemSelectionRange.html
+++ b/docs/pyside/PySide/QtGui/QItemSelectionRange.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QKeyEvent.html
+++ b/docs/pyside/PySide/QtGui/QKeyEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QKeyEventTransition.html
+++ b/docs/pyside/PySide/QtGui/QKeyEventTransition.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QKeySequence.html
+++ b/docs/pyside/PySide/QtGui/QKeySequence.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QLCDNumber.html
+++ b/docs/pyside/PySide/QtGui/QLCDNumber.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QLabel.html
+++ b/docs/pyside/PySide/QtGui/QLabel.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QLayout.html
+++ b/docs/pyside/PySide/QtGui/QLayout.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QLayoutItem.html
+++ b/docs/pyside/PySide/QtGui/QLayoutItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QLineEdit.html
+++ b/docs/pyside/PySide/QtGui/QLineEdit.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QLinearGradient.html
+++ b/docs/pyside/PySide/QtGui/QLinearGradient.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QListView.html
+++ b/docs/pyside/PySide/QtGui/QListView.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QListWidget.html
+++ b/docs/pyside/PySide/QtGui/QListWidget.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QListWidgetItem.html
+++ b/docs/pyside/PySide/QtGui/QListWidgetItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QMacStyle.html
+++ b/docs/pyside/PySide/QtGui/QMacStyle.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QMainWindow.html
+++ b/docs/pyside/PySide/QtGui/QMainWindow.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QMatrix.html
+++ b/docs/pyside/PySide/QtGui/QMatrix.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QMatrix2x2.html
+++ b/docs/pyside/PySide/QtGui/QMatrix2x2.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QMatrix2x3.html
+++ b/docs/pyside/PySide/QtGui/QMatrix2x3.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QMatrix2x4.html
+++ b/docs/pyside/PySide/QtGui/QMatrix2x4.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QMatrix3x2.html
+++ b/docs/pyside/PySide/QtGui/QMatrix3x2.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QMatrix3x3.html
+++ b/docs/pyside/PySide/QtGui/QMatrix3x3.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QMatrix3x4.html
+++ b/docs/pyside/PySide/QtGui/QMatrix3x4.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QMatrix4x2.html
+++ b/docs/pyside/PySide/QtGui/QMatrix4x2.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QMatrix4x3.html
+++ b/docs/pyside/PySide/QtGui/QMatrix4x3.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QMatrix4x4.html
+++ b/docs/pyside/PySide/QtGui/QMatrix4x4.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QMdiArea.html
+++ b/docs/pyside/PySide/QtGui/QMdiArea.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QMdiSubWindow.html
+++ b/docs/pyside/PySide/QtGui/QMdiSubWindow.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QMenu.html
+++ b/docs/pyside/PySide/QtGui/QMenu.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QMenuBar.html
+++ b/docs/pyside/PySide/QtGui/QMenuBar.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QMessageBox.html
+++ b/docs/pyside/PySide/QtGui/QMessageBox.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QMotifStyle.html
+++ b/docs/pyside/PySide/QtGui/QMotifStyle.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QMouseEvent.html
+++ b/docs/pyside/PySide/QtGui/QMouseEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QMouseEventTransition.html
+++ b/docs/pyside/PySide/QtGui/QMouseEventTransition.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QMoveEvent.html
+++ b/docs/pyside/PySide/QtGui/QMoveEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QMovie.html
+++ b/docs/pyside/PySide/QtGui/QMovie.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPageSetupDialog.html
+++ b/docs/pyside/PySide/QtGui/QPageSetupDialog.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPaintDevice.html
+++ b/docs/pyside/PySide/QtGui/QPaintDevice.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPaintEngine.html
+++ b/docs/pyside/PySide/QtGui/QPaintEngine.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPaintEngineState.html
+++ b/docs/pyside/PySide/QtGui/QPaintEngineState.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPaintEvent.html
+++ b/docs/pyside/PySide/QtGui/QPaintEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPainter.PixmapFragment.html
+++ b/docs/pyside/PySide/QtGui/QPainter.PixmapFragment.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPainter.html
+++ b/docs/pyside/PySide/QtGui/QPainter.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPainterPath.Element.html
+++ b/docs/pyside/PySide/QtGui/QPainterPath.Element.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPainterPath.html
+++ b/docs/pyside/PySide/QtGui/QPainterPath.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPainterPathStroker.html
+++ b/docs/pyside/PySide/QtGui/QPainterPathStroker.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPalette.html
+++ b/docs/pyside/PySide/QtGui/QPalette.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPanGesture.html
+++ b/docs/pyside/PySide/QtGui/QPanGesture.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPen.html
+++ b/docs/pyside/PySide/QtGui/QPen.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPicture.html
+++ b/docs/pyside/PySide/QtGui/QPicture.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPictureIO.html
+++ b/docs/pyside/PySide/QtGui/QPictureIO.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPinchGesture.html
+++ b/docs/pyside/PySide/QtGui/QPinchGesture.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPixmap.html
+++ b/docs/pyside/PySide/QtGui/QPixmap.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPixmapCache.Key.html
+++ b/docs/pyside/PySide/QtGui/QPixmapCache.Key.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPixmapCache.html
+++ b/docs/pyside/PySide/QtGui/QPixmapCache.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPlainTextDocumentLayout.html
+++ b/docs/pyside/PySide/QtGui/QPlainTextDocumentLayout.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPlainTextEdit.html
+++ b/docs/pyside/PySide/QtGui/QPlainTextEdit.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPlastiqueStyle.html
+++ b/docs/pyside/PySide/QtGui/QPlastiqueStyle.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPolygon.html
+++ b/docs/pyside/PySide/QtGui/QPolygon.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPolygonF.html
+++ b/docs/pyside/PySide/QtGui/QPolygonF.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPrintDialog.html
+++ b/docs/pyside/PySide/QtGui/QPrintDialog.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPrintEngine.html
+++ b/docs/pyside/PySide/QtGui/QPrintEngine.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPrintPreviewDialog.html
+++ b/docs/pyside/PySide/QtGui/QPrintPreviewDialog.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPrintPreviewWidget.html
+++ b/docs/pyside/PySide/QtGui/QPrintPreviewWidget.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPrinter.html
+++ b/docs/pyside/PySide/QtGui/QPrinter.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPrinterInfo.html
+++ b/docs/pyside/PySide/QtGui/QPrinterInfo.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QProgressBar.html
+++ b/docs/pyside/PySide/QtGui/QProgressBar.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QProgressDialog.html
+++ b/docs/pyside/PySide/QtGui/QProgressDialog.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QProxyModel.html
+++ b/docs/pyside/PySide/QtGui/QProxyModel.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPushButton.html
+++ b/docs/pyside/PySide/QtGui/QPushButton.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QPyTextObject.html
+++ b/docs/pyside/PySide/QtGui/QPyTextObject.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QQuaternion.html
+++ b/docs/pyside/PySide/QtGui/QQuaternion.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QRadialGradient.html
+++ b/docs/pyside/PySide/QtGui/QRadialGradient.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QRadioButton.html
+++ b/docs/pyside/PySide/QtGui/QRadioButton.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QRegExpValidator.html
+++ b/docs/pyside/PySide/QtGui/QRegExpValidator.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QRegion.html
+++ b/docs/pyside/PySide/QtGui/QRegion.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QResizeEvent.html
+++ b/docs/pyside/PySide/QtGui/QResizeEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QRubberBand.html
+++ b/docs/pyside/PySide/QtGui/QRubberBand.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QScrollArea.html
+++ b/docs/pyside/PySide/QtGui/QScrollArea.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QScrollBar.html
+++ b/docs/pyside/PySide/QtGui/QScrollBar.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QSessionManager.html
+++ b/docs/pyside/PySide/QtGui/QSessionManager.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QShortcut.html
+++ b/docs/pyside/PySide/QtGui/QShortcut.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QShortcutEvent.html
+++ b/docs/pyside/PySide/QtGui/QShortcutEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QShowEvent.html
+++ b/docs/pyside/PySide/QtGui/QShowEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QSizeGrip.html
+++ b/docs/pyside/PySide/QtGui/QSizeGrip.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QSizePolicy.html
+++ b/docs/pyside/PySide/QtGui/QSizePolicy.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QSlider.html
+++ b/docs/pyside/PySide/QtGui/QSlider.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QSortFilterProxyModel.html
+++ b/docs/pyside/PySide/QtGui/QSortFilterProxyModel.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QSound.html
+++ b/docs/pyside/PySide/QtGui/QSound.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QSpacerItem.html
+++ b/docs/pyside/PySide/QtGui/QSpacerItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QSpinBox.html
+++ b/docs/pyside/PySide/QtGui/QSpinBox.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QSplashScreen.html
+++ b/docs/pyside/PySide/QtGui/QSplashScreen.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QSplitter.html
+++ b/docs/pyside/PySide/QtGui/QSplitter.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QSplitterHandle.html
+++ b/docs/pyside/PySide/QtGui/QSplitterHandle.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStackedLayout.html
+++ b/docs/pyside/PySide/QtGui/QStackedLayout.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStackedWidget.html
+++ b/docs/pyside/PySide/QtGui/QStackedWidget.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStandardItem.html
+++ b/docs/pyside/PySide/QtGui/QStandardItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStandardItemModel.html
+++ b/docs/pyside/PySide/QtGui/QStandardItemModel.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStatusBar.html
+++ b/docs/pyside/PySide/QtGui/QStatusBar.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStatusTipEvent.html
+++ b/docs/pyside/PySide/QtGui/QStatusTipEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStringListModel.html
+++ b/docs/pyside/PySide/QtGui/QStringListModel.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyle.html
+++ b/docs/pyside/PySide/QtGui/QStyle.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleFactory.html
+++ b/docs/pyside/PySide/QtGui/QStyleFactory.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleHintReturn.html
+++ b/docs/pyside/PySide/QtGui/QStyleHintReturn.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleHintReturnMask.html
+++ b/docs/pyside/PySide/QtGui/QStyleHintReturnMask.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleHintReturnVariant.html
+++ b/docs/pyside/PySide/QtGui/QStyleHintReturnVariant.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOption.html
+++ b/docs/pyside/PySide/QtGui/QStyleOption.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionButton.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionButton.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionComboBox.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionComboBox.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionComplex.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionComplex.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionDockWidget.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionDockWidget.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionDockWidgetV2.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionDockWidgetV2.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionFocusRect.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionFocusRect.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionFrame.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionFrame.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionFrameV2.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionFrameV2.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionFrameV3.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionFrameV3.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionGraphicsItem.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionGraphicsItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionGroupBox.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionGroupBox.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionHeader.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionHeader.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionMenuItem.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionMenuItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionProgressBar.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionProgressBar.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionProgressBarV2.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionProgressBarV2.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionRubberBand.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionRubberBand.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionSizeGrip.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionSizeGrip.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionSlider.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionSlider.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionSpinBox.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionSpinBox.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionTab.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionTab.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionTabBarBase.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionTabBarBase.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionTabBarBaseV2.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionTabBarBaseV2.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionTabV2.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionTabV2.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionTabV3.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionTabV3.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionTabWidgetFrame.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionTabWidgetFrame.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionTitleBar.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionTitleBar.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionToolBar.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionToolBar.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionToolBox.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionToolBox.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionToolBoxV2.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionToolBoxV2.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionToolButton.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionToolButton.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionViewItem.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionViewItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionViewItemV2.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionViewItemV2.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionViewItemV3.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionViewItemV3.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyleOptionViewItemV4.html
+++ b/docs/pyside/PySide/QtGui/QStyleOptionViewItemV4.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStylePainter.html
+++ b/docs/pyside/PySide/QtGui/QStylePainter.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QStyledItemDelegate.html
+++ b/docs/pyside/PySide/QtGui/QStyledItemDelegate.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QSwipeGesture.html
+++ b/docs/pyside/PySide/QtGui/QSwipeGesture.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QSyntaxHighlighter.html
+++ b/docs/pyside/PySide/QtGui/QSyntaxHighlighter.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QSystemTrayIcon.html
+++ b/docs/pyside/PySide/QtGui/QSystemTrayIcon.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTabBar.html
+++ b/docs/pyside/PySide/QtGui/QTabBar.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTabWidget.html
+++ b/docs/pyside/PySide/QtGui/QTabWidget.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTableView.html
+++ b/docs/pyside/PySide/QtGui/QTableView.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTableWidget.html
+++ b/docs/pyside/PySide/QtGui/QTableWidget.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTableWidgetItem.html
+++ b/docs/pyside/PySide/QtGui/QTableWidgetItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTableWidgetSelectionRange.html
+++ b/docs/pyside/PySide/QtGui/QTableWidgetSelectionRange.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTabletEvent.html
+++ b/docs/pyside/PySide/QtGui/QTabletEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTapAndHoldGesture.html
+++ b/docs/pyside/PySide/QtGui/QTapAndHoldGesture.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTapGesture.html
+++ b/docs/pyside/PySide/QtGui/QTapGesture.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextBlock.html
+++ b/docs/pyside/PySide/QtGui/QTextBlock.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextBlock.iterator.html
+++ b/docs/pyside/PySide/QtGui/QTextBlock.iterator.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextBlockFormat.html
+++ b/docs/pyside/PySide/QtGui/QTextBlockFormat.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextBlockGroup.html
+++ b/docs/pyside/PySide/QtGui/QTextBlockGroup.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextBlockUserData.html
+++ b/docs/pyside/PySide/QtGui/QTextBlockUserData.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextBrowser.html
+++ b/docs/pyside/PySide/QtGui/QTextBrowser.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextCharFormat.html
+++ b/docs/pyside/PySide/QtGui/QTextCharFormat.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextCursor.html
+++ b/docs/pyside/PySide/QtGui/QTextCursor.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextDocument.html
+++ b/docs/pyside/PySide/QtGui/QTextDocument.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextDocumentFragment.html
+++ b/docs/pyside/PySide/QtGui/QTextDocumentFragment.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextEdit.ExtraSelection.html
+++ b/docs/pyside/PySide/QtGui/QTextEdit.ExtraSelection.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextEdit.html
+++ b/docs/pyside/PySide/QtGui/QTextEdit.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextFormat.html
+++ b/docs/pyside/PySide/QtGui/QTextFormat.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextFragment.html
+++ b/docs/pyside/PySide/QtGui/QTextFragment.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextFrame.html
+++ b/docs/pyside/PySide/QtGui/QTextFrame.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextFrame.iterator.html
+++ b/docs/pyside/PySide/QtGui/QTextFrame.iterator.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextFrameFormat.html
+++ b/docs/pyside/PySide/QtGui/QTextFrameFormat.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextImageFormat.html
+++ b/docs/pyside/PySide/QtGui/QTextImageFormat.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextInlineObject.html
+++ b/docs/pyside/PySide/QtGui/QTextInlineObject.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextItem.html
+++ b/docs/pyside/PySide/QtGui/QTextItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextLayout.FormatRange.html
+++ b/docs/pyside/PySide/QtGui/QTextLayout.FormatRange.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextLayout.html
+++ b/docs/pyside/PySide/QtGui/QTextLayout.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextLength.html
+++ b/docs/pyside/PySide/QtGui/QTextLength.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextLine.html
+++ b/docs/pyside/PySide/QtGui/QTextLine.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextList.html
+++ b/docs/pyside/PySide/QtGui/QTextList.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextListFormat.html
+++ b/docs/pyside/PySide/QtGui/QTextListFormat.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextObject.html
+++ b/docs/pyside/PySide/QtGui/QTextObject.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextObjectInterface.html
+++ b/docs/pyside/PySide/QtGui/QTextObjectInterface.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextOption.Tab.html
+++ b/docs/pyside/PySide/QtGui/QTextOption.Tab.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextOption.html
+++ b/docs/pyside/PySide/QtGui/QTextOption.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextTable.html
+++ b/docs/pyside/PySide/QtGui/QTextTable.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextTableCell.html
+++ b/docs/pyside/PySide/QtGui/QTextTableCell.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextTableCellFormat.html
+++ b/docs/pyside/PySide/QtGui/QTextTableCellFormat.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTextTableFormat.html
+++ b/docs/pyside/PySide/QtGui/QTextTableFormat.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTileRules.html
+++ b/docs/pyside/PySide/QtGui/QTileRules.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTimeEdit.html
+++ b/docs/pyside/PySide/QtGui/QTimeEdit.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QToolBar.html
+++ b/docs/pyside/PySide/QtGui/QToolBar.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QToolBarChangeEvent.html
+++ b/docs/pyside/PySide/QtGui/QToolBarChangeEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QToolBox.html
+++ b/docs/pyside/PySide/QtGui/QToolBox.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QToolButton.html
+++ b/docs/pyside/PySide/QtGui/QToolButton.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QToolTip.html
+++ b/docs/pyside/PySide/QtGui/QToolTip.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTouchEvent.TouchPoint.html
+++ b/docs/pyside/PySide/QtGui/QTouchEvent.TouchPoint.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTouchEvent.html
+++ b/docs/pyside/PySide/QtGui/QTouchEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTransform.html
+++ b/docs/pyside/PySide/QtGui/QTransform.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTreeView.html
+++ b/docs/pyside/PySide/QtGui/QTreeView.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTreeWidget.html
+++ b/docs/pyside/PySide/QtGui/QTreeWidget.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTreeWidgetItem.html
+++ b/docs/pyside/PySide/QtGui/QTreeWidgetItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QTreeWidgetItemIterator.html
+++ b/docs/pyside/PySide/QtGui/QTreeWidgetItemIterator.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QUndoCommand.html
+++ b/docs/pyside/PySide/QtGui/QUndoCommand.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QUndoGroup.html
+++ b/docs/pyside/PySide/QtGui/QUndoGroup.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QUndoStack.html
+++ b/docs/pyside/PySide/QtGui/QUndoStack.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QUndoView.html
+++ b/docs/pyside/PySide/QtGui/QUndoView.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QVBoxLayout.html
+++ b/docs/pyside/PySide/QtGui/QVBoxLayout.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QValidator.html
+++ b/docs/pyside/PySide/QtGui/QValidator.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QVector2D.html
+++ b/docs/pyside/PySide/QtGui/QVector2D.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QVector3D.html
+++ b/docs/pyside/PySide/QtGui/QVector3D.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QVector4D.html
+++ b/docs/pyside/PySide/QtGui/QVector4D.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QWhatsThis.html
+++ b/docs/pyside/PySide/QtGui/QWhatsThis.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QWhatsThisClickedEvent.html
+++ b/docs/pyside/PySide/QtGui/QWhatsThisClickedEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QWheelEvent.html
+++ b/docs/pyside/PySide/QtGui/QWheelEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QWidget.html
+++ b/docs/pyside/PySide/QtGui/QWidget.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QWidgetAction.html
+++ b/docs/pyside/PySide/QtGui/QWidgetAction.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QWidgetItem.html
+++ b/docs/pyside/PySide/QtGui/QWidgetItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QWindowStateChangeEvent.html
+++ b/docs/pyside/PySide/QtGui/QWindowStateChangeEvent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QWindowsStyle.html
+++ b/docs/pyside/PySide/QtGui/QWindowsStyle.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QWizard.html
+++ b/docs/pyside/PySide/QtGui/QWizard.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QWizardPage.html
+++ b/docs/pyside/PySide/QtGui/QWizardPage.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/QWorkspace.html
+++ b/docs/pyside/PySide/QtGui/QWorkspace.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtGui/index.html
+++ b/docs/pyside/PySide/QtGui/index.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtHelp/QHelpContentItem.html
+++ b/docs/pyside/PySide/QtHelp/QHelpContentItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtHelp/QHelpContentModel.html
+++ b/docs/pyside/PySide/QtHelp/QHelpContentModel.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtHelp/QHelpContentWidget.html
+++ b/docs/pyside/PySide/QtHelp/QHelpContentWidget.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtHelp/QHelpEngine.html
+++ b/docs/pyside/PySide/QtHelp/QHelpEngine.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtHelp/QHelpEngineCore.html
+++ b/docs/pyside/PySide/QtHelp/QHelpEngineCore.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtHelp/QHelpIndexModel.html
+++ b/docs/pyside/PySide/QtHelp/QHelpIndexModel.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtHelp/QHelpIndexWidget.html
+++ b/docs/pyside/PySide/QtHelp/QHelpIndexWidget.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtHelp/QHelpSearchEngine.html
+++ b/docs/pyside/PySide/QtHelp/QHelpSearchEngine.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtHelp/QHelpSearchQuery.html
+++ b/docs/pyside/PySide/QtHelp/QHelpSearchQuery.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtHelp/QHelpSearchQueryWidget.html
+++ b/docs/pyside/PySide/QtHelp/QHelpSearchQueryWidget.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtHelp/QHelpSearchResultWidget.html
+++ b/docs/pyside/PySide/QtHelp/QHelpSearchResultWidget.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtHelp/index.html
+++ b/docs/pyside/PySide/QtHelp/index.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtMultimedia/QAbstractAudioDeviceInfo.html
+++ b/docs/pyside/PySide/QtMultimedia/QAbstractAudioDeviceInfo.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtMultimedia/QAbstractAudioInput.html
+++ b/docs/pyside/PySide/QtMultimedia/QAbstractAudioInput.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtMultimedia/QAbstractAudioOutput.html
+++ b/docs/pyside/PySide/QtMultimedia/QAbstractAudioOutput.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtMultimedia/QAbstractVideoBuffer.html
+++ b/docs/pyside/PySide/QtMultimedia/QAbstractVideoBuffer.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtMultimedia/QAbstractVideoSurface.html
+++ b/docs/pyside/PySide/QtMultimedia/QAbstractVideoSurface.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtMultimedia/QAudio.html
+++ b/docs/pyside/PySide/QtMultimedia/QAudio.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtMultimedia/QAudioDeviceInfo.html
+++ b/docs/pyside/PySide/QtMultimedia/QAudioDeviceInfo.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtMultimedia/QAudioEngineFactoryInterface.html
+++ b/docs/pyside/PySide/QtMultimedia/QAudioEngineFactoryInterface.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtMultimedia/QAudioEnginePlugin.html
+++ b/docs/pyside/PySide/QtMultimedia/QAudioEnginePlugin.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtMultimedia/QAudioFormat.html
+++ b/docs/pyside/PySide/QtMultimedia/QAudioFormat.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtMultimedia/QAudioInput.html
+++ b/docs/pyside/PySide/QtMultimedia/QAudioInput.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtMultimedia/QAudioOutput.html
+++ b/docs/pyside/PySide/QtMultimedia/QAudioOutput.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtMultimedia/QVideoFrame.html
+++ b/docs/pyside/PySide/QtMultimedia/QVideoFrame.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtMultimedia/QVideoSurfaceFormat.html
+++ b/docs/pyside/PySide/QtMultimedia/QVideoSurfaceFormat.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtMultimedia/index.html
+++ b/docs/pyside/PySide/QtMultimedia/index.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QAbstractNetworkCache.html
+++ b/docs/pyside/PySide/QtNetwork/QAbstractNetworkCache.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QAbstractSocket.html
+++ b/docs/pyside/PySide/QtNetwork/QAbstractSocket.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QAuthenticator.html
+++ b/docs/pyside/PySide/QtNetwork/QAuthenticator.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QFtp.html
+++ b/docs/pyside/PySide/QtNetwork/QFtp.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QHostAddress.html
+++ b/docs/pyside/PySide/QtNetwork/QHostAddress.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QHostInfo.html
+++ b/docs/pyside/PySide/QtNetwork/QHostInfo.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QHttp.html
+++ b/docs/pyside/PySide/QtNetwork/QHttp.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QHttpHeader.html
+++ b/docs/pyside/PySide/QtNetwork/QHttpHeader.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QHttpRequestHeader.html
+++ b/docs/pyside/PySide/QtNetwork/QHttpRequestHeader.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QHttpResponseHeader.html
+++ b/docs/pyside/PySide/QtNetwork/QHttpResponseHeader.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QIPv6Address.html
+++ b/docs/pyside/PySide/QtNetwork/QIPv6Address.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QLocalServer.html
+++ b/docs/pyside/PySide/QtNetwork/QLocalServer.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QLocalSocket.html
+++ b/docs/pyside/PySide/QtNetwork/QLocalSocket.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QNetworkAccessManager.html
+++ b/docs/pyside/PySide/QtNetwork/QNetworkAccessManager.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QNetworkAddressEntry.html
+++ b/docs/pyside/PySide/QtNetwork/QNetworkAddressEntry.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QNetworkCacheMetaData.html
+++ b/docs/pyside/PySide/QtNetwork/QNetworkCacheMetaData.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QNetworkConfiguration.html
+++ b/docs/pyside/PySide/QtNetwork/QNetworkConfiguration.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QNetworkConfigurationManager.html
+++ b/docs/pyside/PySide/QtNetwork/QNetworkConfigurationManager.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QNetworkCookie.html
+++ b/docs/pyside/PySide/QtNetwork/QNetworkCookie.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QNetworkCookieJar.html
+++ b/docs/pyside/PySide/QtNetwork/QNetworkCookieJar.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QNetworkDiskCache.html
+++ b/docs/pyside/PySide/QtNetwork/QNetworkDiskCache.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QNetworkInterface.html
+++ b/docs/pyside/PySide/QtNetwork/QNetworkInterface.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QNetworkProxy.html
+++ b/docs/pyside/PySide/QtNetwork/QNetworkProxy.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QNetworkProxyFactory.html
+++ b/docs/pyside/PySide/QtNetwork/QNetworkProxyFactory.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QNetworkProxyQuery.html
+++ b/docs/pyside/PySide/QtNetwork/QNetworkProxyQuery.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QNetworkReply.html
+++ b/docs/pyside/PySide/QtNetwork/QNetworkReply.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QNetworkRequest.html
+++ b/docs/pyside/PySide/QtNetwork/QNetworkRequest.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QNetworkSession.html
+++ b/docs/pyside/PySide/QtNetwork/QNetworkSession.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QSsl.html
+++ b/docs/pyside/PySide/QtNetwork/QSsl.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QSslCertificate.html
+++ b/docs/pyside/PySide/QtNetwork/QSslCertificate.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QSslCipher.html
+++ b/docs/pyside/PySide/QtNetwork/QSslCipher.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QSslConfiguration.html
+++ b/docs/pyside/PySide/QtNetwork/QSslConfiguration.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QSslError.html
+++ b/docs/pyside/PySide/QtNetwork/QSslError.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QSslKey.html
+++ b/docs/pyside/PySide/QtNetwork/QSslKey.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QSslSocket.html
+++ b/docs/pyside/PySide/QtNetwork/QSslSocket.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QTcpServer.html
+++ b/docs/pyside/PySide/QtNetwork/QTcpServer.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QTcpSocket.html
+++ b/docs/pyside/PySide/QtNetwork/QTcpSocket.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QUdpSocket.html
+++ b/docs/pyside/PySide/QtNetwork/QUdpSocket.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/QUrlInfo.html
+++ b/docs/pyside/PySide/QtNetwork/QUrlInfo.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtNetwork/index.html
+++ b/docs/pyside/PySide/QtNetwork/index.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtOpenGL/QGL.html
+++ b/docs/pyside/PySide/QtOpenGL/QGL.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtOpenGL/QGLBuffer.html
+++ b/docs/pyside/PySide/QtOpenGL/QGLBuffer.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtOpenGL/QGLColormap.html
+++ b/docs/pyside/PySide/QtOpenGL/QGLColormap.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtOpenGL/QGLContext.html
+++ b/docs/pyside/PySide/QtOpenGL/QGLContext.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtOpenGL/QGLFormat.html
+++ b/docs/pyside/PySide/QtOpenGL/QGLFormat.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtOpenGL/QGLFramebufferObject.html
+++ b/docs/pyside/PySide/QtOpenGL/QGLFramebufferObject.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtOpenGL/QGLFramebufferObjectFormat.html
+++ b/docs/pyside/PySide/QtOpenGL/QGLFramebufferObjectFormat.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtOpenGL/QGLPixelBuffer.html
+++ b/docs/pyside/PySide/QtOpenGL/QGLPixelBuffer.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtOpenGL/QGLShader.html
+++ b/docs/pyside/PySide/QtOpenGL/QGLShader.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtOpenGL/QGLShaderProgram.html
+++ b/docs/pyside/PySide/QtOpenGL/QGLShaderProgram.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtOpenGL/QGLWidget.html
+++ b/docs/pyside/PySide/QtOpenGL/QGLWidget.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtOpenGL/index.html
+++ b/docs/pyside/PySide/QtOpenGL/index.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtScript/QScriptClass.html
+++ b/docs/pyside/PySide/QtScript/QScriptClass.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtScript/QScriptClassPropertyIterator.html
+++ b/docs/pyside/PySide/QtScript/QScriptClassPropertyIterator.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtScript/QScriptContext.html
+++ b/docs/pyside/PySide/QtScript/QScriptContext.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtScript/QScriptContextInfo.html
+++ b/docs/pyside/PySide/QtScript/QScriptContextInfo.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtScript/QScriptEngine.html
+++ b/docs/pyside/PySide/QtScript/QScriptEngine.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtScript/QScriptEngineAgent.html
+++ b/docs/pyside/PySide/QtScript/QScriptEngineAgent.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtScript/QScriptExtensionInterface.html
+++ b/docs/pyside/PySide/QtScript/QScriptExtensionInterface.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtScript/QScriptExtensionPlugin.html
+++ b/docs/pyside/PySide/QtScript/QScriptExtensionPlugin.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtScript/QScriptProgram.html
+++ b/docs/pyside/PySide/QtScript/QScriptProgram.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtScript/QScriptString.html
+++ b/docs/pyside/PySide/QtScript/QScriptString.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtScript/QScriptValue.html
+++ b/docs/pyside/PySide/QtScript/QScriptValue.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtScript/QScriptValueIterator.html
+++ b/docs/pyside/PySide/QtScript/QScriptValueIterator.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtScript/QScriptable.html
+++ b/docs/pyside/PySide/QtScript/QScriptable.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtScript/index.html
+++ b/docs/pyside/PySide/QtScript/index.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtScript/ools.html
+++ b/docs/pyside/PySide/QtScript/ools.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtScriptTools/QScriptEngineDebugger.html
+++ b/docs/pyside/PySide/QtScriptTools/QScriptEngineDebugger.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtScriptTools/index.html
+++ b/docs/pyside/PySide/QtScriptTools/index.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtSql/QSql.html
+++ b/docs/pyside/PySide/QtSql/QSql.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtSql/QSqlDatabase.html
+++ b/docs/pyside/PySide/QtSql/QSqlDatabase.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtSql/QSqlDriver.html
+++ b/docs/pyside/PySide/QtSql/QSqlDriver.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtSql/QSqlDriverCreatorBase.html
+++ b/docs/pyside/PySide/QtSql/QSqlDriverCreatorBase.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtSql/QSqlError.html
+++ b/docs/pyside/PySide/QtSql/QSqlError.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtSql/QSqlField.html
+++ b/docs/pyside/PySide/QtSql/QSqlField.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtSql/QSqlIndex.html
+++ b/docs/pyside/PySide/QtSql/QSqlIndex.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtSql/QSqlQuery.html
+++ b/docs/pyside/PySide/QtSql/QSqlQuery.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtSql/QSqlQueryModel.html
+++ b/docs/pyside/PySide/QtSql/QSqlQueryModel.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtSql/QSqlRecord.html
+++ b/docs/pyside/PySide/QtSql/QSqlRecord.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtSql/QSqlRelation.html
+++ b/docs/pyside/PySide/QtSql/QSqlRelation.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtSql/QSqlRelationalDelegate.html
+++ b/docs/pyside/PySide/QtSql/QSqlRelationalDelegate.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtSql/QSqlRelationalTableModel.html
+++ b/docs/pyside/PySide/QtSql/QSqlRelationalTableModel.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtSql/QSqlResult.html
+++ b/docs/pyside/PySide/QtSql/QSqlResult.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtSql/QSqlTableModel.html
+++ b/docs/pyside/PySide/QtSql/QSqlTableModel.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtSql/index.html
+++ b/docs/pyside/PySide/QtSql/index.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtSvg/QGraphicsSvgItem.html
+++ b/docs/pyside/PySide/QtSvg/QGraphicsSvgItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtSvg/QSvgGenerator.html
+++ b/docs/pyside/PySide/QtSvg/QSvgGenerator.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtSvg/QSvgRenderer.html
+++ b/docs/pyside/PySide/QtSvg/QSvgRenderer.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtSvg/QSvgWidget.html
+++ b/docs/pyside/PySide/QtSvg/QSvgWidget.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtSvg/index.html
+++ b/docs/pyside/PySide/QtSvg/index.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtTest/QTest.QTouchEventSequence.html
+++ b/docs/pyside/PySide/QtTest/QTest.QTouchEventSequence.html
@@ -29,7 +29,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/PySide/QtTest/QTest.html
+++ b/docs/pyside/PySide/QtTest/QTest.html
@@ -29,7 +29,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/PySide/QtTest/index.html
+++ b/docs/pyside/PySide/QtTest/index.html
@@ -29,7 +29,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/PySide/QtUiTools/QUiLoader.html
+++ b/docs/pyside/PySide/QtUiTools/QUiLoader.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>
@@ -481,7 +481,7 @@ loading a <cite>.ui</cite> file. The custom widget type is passed via the <tt cl
 This is needed when you want to override a virtual method of some widget in the interface,
 since duck punching will not work with widgets created by QUiLoader based on the contents
 of the <cite>.ui</cite> file.</p>
-<p>(Remember that <a class="reference external" href="http://www.pyside.org/docs/shiboken/wordsofadvice.html#duck-punching-and-virtual-methods">duck punching virtual methods is an invitation for your own demise!</a>)</p>
+<p>(Remember that <a class="reference external" href="https://pyside.github.io/docs/shiboken/wordsofadvice.html#duck-punching-and-virtual-methods">duck punching virtual methods is an invitation for your own demise!</a>)</p>
 <p>Let&#8217;s see an obvious example. If you want to create a new widget it&#8217;s probable you&#8217;ll end up
 overriding <a class="reference internal" href="../QtGui/QWidget.html#PySide.QtGui.QWidget" title="PySide.QtGui.QWidget"><tt class="xref py py-class docutils literal"><span class="pre">QWidget</span></tt></a>&#8216;s <tt class="xref py py-meth docutils literal"><span class="pre">paintEvent()</span></tt> method.</p>
 <div class="highlight-python"><div class="highlight"><pre><span class="k">class</span> <span class="nc">Circle</span><span class="p">(</span><span class="n">QWidget</span><span class="p">):</span>

--- a/docs/pyside/PySide/QtUiTools/index.html
+++ b/docs/pyside/PySide/QtUiTools/index.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QGraphicsWebView.html
+++ b/docs/pyside/PySide/QtWebKit/QGraphicsWebView.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QWebDatabase.html
+++ b/docs/pyside/PySide/QtWebKit/QWebDatabase.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QWebElement.html
+++ b/docs/pyside/PySide/QtWebKit/QWebElement.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QWebElementCollection.html
+++ b/docs/pyside/PySide/QtWebKit/QWebElementCollection.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QWebFrame.html
+++ b/docs/pyside/PySide/QtWebKit/QWebFrame.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QWebHistory.html
+++ b/docs/pyside/PySide/QtWebKit/QWebHistory.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QWebHistoryInterface.html
+++ b/docs/pyside/PySide/QtWebKit/QWebHistoryInterface.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QWebHistoryItem.html
+++ b/docs/pyside/PySide/QtWebKit/QWebHistoryItem.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QWebHitTestResult.html
+++ b/docs/pyside/PySide/QtWebKit/QWebHitTestResult.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QWebInspector.html
+++ b/docs/pyside/PySide/QtWebKit/QWebInspector.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QWebPage.ChooseMultipleFilesExtensionOption.html
+++ b/docs/pyside/PySide/QtWebKit/QWebPage.ChooseMultipleFilesExtensionOption.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QWebPage.ChooseMultipleFilesExtensionReturn.html
+++ b/docs/pyside/PySide/QtWebKit/QWebPage.ChooseMultipleFilesExtensionReturn.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QWebPage.ErrorPageExtensionOption.html
+++ b/docs/pyside/PySide/QtWebKit/QWebPage.ErrorPageExtensionOption.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QWebPage.ErrorPageExtensionReturn.html
+++ b/docs/pyside/PySide/QtWebKit/QWebPage.ErrorPageExtensionReturn.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QWebPage.ExtensionOption.html
+++ b/docs/pyside/PySide/QtWebKit/QWebPage.ExtensionOption.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QWebPage.ExtensionReturn.html
+++ b/docs/pyside/PySide/QtWebKit/QWebPage.ExtensionReturn.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QWebPage.html
+++ b/docs/pyside/PySide/QtWebKit/QWebPage.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QWebPluginFactory.MimeType.html
+++ b/docs/pyside/PySide/QtWebKit/QWebPluginFactory.MimeType.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QWebPluginFactory.Plugin.html
+++ b/docs/pyside/PySide/QtWebKit/QWebPluginFactory.Plugin.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QWebPluginFactory.html
+++ b/docs/pyside/PySide/QtWebKit/QWebPluginFactory.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QWebSecurityOrigin.html
+++ b/docs/pyside/PySide/QtWebKit/QWebSecurityOrigin.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QWebSettings.html
+++ b/docs/pyside/PySide/QtWebKit/QWebSettings.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/QWebView.html
+++ b/docs/pyside/PySide/QtWebKit/QWebView.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/WebCore.html
+++ b/docs/pyside/PySide/QtWebKit/WebCore.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtWebKit/index.html
+++ b/docs/pyside/PySide/QtWebKit/index.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QDomAttr.html
+++ b/docs/pyside/PySide/QtXml/QDomAttr.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QDomCDATASection.html
+++ b/docs/pyside/PySide/QtXml/QDomCDATASection.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QDomCharacterData.html
+++ b/docs/pyside/PySide/QtXml/QDomCharacterData.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QDomComment.html
+++ b/docs/pyside/PySide/QtXml/QDomComment.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QDomDocument.html
+++ b/docs/pyside/PySide/QtXml/QDomDocument.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QDomDocumentFragment.html
+++ b/docs/pyside/PySide/QtXml/QDomDocumentFragment.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QDomDocumentType.html
+++ b/docs/pyside/PySide/QtXml/QDomDocumentType.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QDomElement.html
+++ b/docs/pyside/PySide/QtXml/QDomElement.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QDomEntity.html
+++ b/docs/pyside/PySide/QtXml/QDomEntity.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QDomEntityReference.html
+++ b/docs/pyside/PySide/QtXml/QDomEntityReference.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QDomImplementation.html
+++ b/docs/pyside/PySide/QtXml/QDomImplementation.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QDomNamedNodeMap.html
+++ b/docs/pyside/PySide/QtXml/QDomNamedNodeMap.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QDomNode.html
+++ b/docs/pyside/PySide/QtXml/QDomNode.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QDomNodeList.html
+++ b/docs/pyside/PySide/QtXml/QDomNodeList.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QDomNotation.html
+++ b/docs/pyside/PySide/QtXml/QDomNotation.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QDomProcessingInstruction.html
+++ b/docs/pyside/PySide/QtXml/QDomProcessingInstruction.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QDomText.html
+++ b/docs/pyside/PySide/QtXml/QDomText.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QXmlAttributes.html
+++ b/docs/pyside/PySide/QtXml/QXmlAttributes.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QXmlContentHandler.html
+++ b/docs/pyside/PySide/QtXml/QXmlContentHandler.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QXmlDTDHandler.html
+++ b/docs/pyside/PySide/QtXml/QXmlDTDHandler.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QXmlDeclHandler.html
+++ b/docs/pyside/PySide/QtXml/QXmlDeclHandler.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QXmlDefaultHandler.html
+++ b/docs/pyside/PySide/QtXml/QXmlDefaultHandler.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QXmlEntityResolver.html
+++ b/docs/pyside/PySide/QtXml/QXmlEntityResolver.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QXmlErrorHandler.html
+++ b/docs/pyside/PySide/QtXml/QXmlErrorHandler.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QXmlInputSource.html
+++ b/docs/pyside/PySide/QtXml/QXmlInputSource.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QXmlLexicalHandler.html
+++ b/docs/pyside/PySide/QtXml/QXmlLexicalHandler.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QXmlLocator.html
+++ b/docs/pyside/PySide/QtXml/QXmlLocator.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QXmlNamespaceSupport.html
+++ b/docs/pyside/PySide/QtXml/QXmlNamespaceSupport.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QXmlParseException.html
+++ b/docs/pyside/PySide/QtXml/QXmlParseException.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QXmlReader.html
+++ b/docs/pyside/PySide/QtXml/QXmlReader.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/QXmlSimpleReader.html
+++ b/docs/pyside/PySide/QtXml/QXmlSimpleReader.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/atterns.html
+++ b/docs/pyside/PySide/QtXml/atterns.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXml/index.html
+++ b/docs/pyside/PySide/QtXml/index.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/QtXmlPatterns/QAbstractMessageHandler.html
+++ b/docs/pyside/PySide/QtXmlPatterns/QAbstractMessageHandler.html
@@ -29,7 +29,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/PySide/QtXmlPatterns/QAbstractUriResolver.html
+++ b/docs/pyside/PySide/QtXmlPatterns/QAbstractUriResolver.html
@@ -29,7 +29,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/PySide/QtXmlPatterns/QAbstractXmlNodeModel.html
+++ b/docs/pyside/PySide/QtXmlPatterns/QAbstractXmlNodeModel.html
@@ -29,7 +29,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/PySide/QtXmlPatterns/QAbstractXmlReceiver.html
+++ b/docs/pyside/PySide/QtXmlPatterns/QAbstractXmlReceiver.html
@@ -29,7 +29,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/PySide/QtXmlPatterns/QSourceLocation.html
+++ b/docs/pyside/PySide/QtXmlPatterns/QSourceLocation.html
@@ -29,7 +29,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/PySide/QtXmlPatterns/QXmlFormatter.html
+++ b/docs/pyside/PySide/QtXmlPatterns/QXmlFormatter.html
@@ -29,7 +29,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/PySide/QtXmlPatterns/QXmlItem.html
+++ b/docs/pyside/PySide/QtXmlPatterns/QXmlItem.html
@@ -29,7 +29,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/PySide/QtXmlPatterns/QXmlName.html
+++ b/docs/pyside/PySide/QtXmlPatterns/QXmlName.html
@@ -29,7 +29,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/PySide/QtXmlPatterns/QXmlNamePool.html
+++ b/docs/pyside/PySide/QtXmlPatterns/QXmlNamePool.html
@@ -29,7 +29,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/PySide/QtXmlPatterns/QXmlNodeModelIndex.html
+++ b/docs/pyside/PySide/QtXmlPatterns/QXmlNodeModelIndex.html
@@ -29,7 +29,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/PySide/QtXmlPatterns/QXmlQuery.html
+++ b/docs/pyside/PySide/QtXmlPatterns/QXmlQuery.html
@@ -29,7 +29,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/PySide/QtXmlPatterns/QXmlResultItems.html
+++ b/docs/pyside/PySide/QtXmlPatterns/QXmlResultItems.html
@@ -29,7 +29,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/PySide/QtXmlPatterns/QXmlSchema.html
+++ b/docs/pyside/PySide/QtXmlPatterns/QXmlSchema.html
@@ -29,7 +29,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/PySide/QtXmlPatterns/QXmlSchemaValidator.html
+++ b/docs/pyside/PySide/QtXmlPatterns/QXmlSchemaValidator.html
@@ -29,7 +29,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/PySide/QtXmlPatterns/QXmlSerializer.html
+++ b/docs/pyside/PySide/QtXmlPatterns/QXmlSerializer.html
@@ -29,7 +29,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/PySide/QtXmlPatterns/index.html
+++ b/docs/pyside/PySide/QtXmlPatterns/index.html
@@ -29,7 +29,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/PySide/phonon/Phonon.AbstractAudioOutput.html
+++ b/docs/pyside/PySide/phonon/Phonon.AbstractAudioOutput.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.AbstractMediaStream.html
+++ b/docs/pyside/PySide/phonon/Phonon.AbstractMediaStream.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.AbstractVideoOutput.html
+++ b/docs/pyside/PySide/phonon/Phonon.AbstractVideoOutput.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.AddonInterface.html
+++ b/docs/pyside/PySide/phonon/Phonon.AddonInterface.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.AudioCaptureDevice.html
+++ b/docs/pyside/PySide/phonon/Phonon.AudioCaptureDevice.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.AudioChannelDescription.html
+++ b/docs/pyside/PySide/phonon/Phonon.AudioChannelDescription.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.AudioOutput.html
+++ b/docs/pyside/PySide/phonon/Phonon.AudioOutput.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.AudioOutputDevice.html
+++ b/docs/pyside/PySide/phonon/Phonon.AudioOutputDevice.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.AudioOutputDeviceModel.html
+++ b/docs/pyside/PySide/phonon/Phonon.AudioOutputDeviceModel.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.BackendCapabilities.Notifier.html
+++ b/docs/pyside/PySide/phonon/Phonon.BackendCapabilities.Notifier.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.BackendCapabilities.html
+++ b/docs/pyside/PySide/phonon/Phonon.BackendCapabilities.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.BackendInterface.html
+++ b/docs/pyside/PySide/phonon/Phonon.BackendInterface.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.Effect.html
+++ b/docs/pyside/PySide/phonon/Phonon.Effect.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.EffectDescription.html
+++ b/docs/pyside/PySide/phonon/Phonon.EffectDescription.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.EffectDescriptionModel.html
+++ b/docs/pyside/PySide/phonon/Phonon.EffectDescriptionModel.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.EffectInterface.html
+++ b/docs/pyside/PySide/phonon/Phonon.EffectInterface.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.EffectParameter.html
+++ b/docs/pyside/PySide/phonon/Phonon.EffectParameter.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.EffectWidget.html
+++ b/docs/pyside/PySide/phonon/Phonon.EffectWidget.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.MediaController.html
+++ b/docs/pyside/PySide/phonon/Phonon.MediaController.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.MediaNode.html
+++ b/docs/pyside/PySide/phonon/Phonon.MediaNode.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.MediaObject.html
+++ b/docs/pyside/PySide/phonon/Phonon.MediaObject.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.MediaObjectInterface.html
+++ b/docs/pyside/PySide/phonon/Phonon.MediaObjectInterface.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.MediaSource.html
+++ b/docs/pyside/PySide/phonon/Phonon.MediaSource.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.Path.html
+++ b/docs/pyside/PySide/phonon/Phonon.Path.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.PlatformPlugin.html
+++ b/docs/pyside/PySide/phonon/Phonon.PlatformPlugin.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.SeekSlider.html
+++ b/docs/pyside/PySide/phonon/Phonon.SeekSlider.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.StreamInterface.html
+++ b/docs/pyside/PySide/phonon/Phonon.StreamInterface.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.SubtitleDescription.html
+++ b/docs/pyside/PySide/phonon/Phonon.SubtitleDescription.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.VideoPlayer.html
+++ b/docs/pyside/PySide/phonon/Phonon.VideoPlayer.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.VideoWidget.html
+++ b/docs/pyside/PySide/phonon/Phonon.VideoWidget.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.VideoWidgetInterface.html
+++ b/docs/pyside/PySide/phonon/Phonon.VideoWidgetInterface.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.VolumeFaderEffect.html
+++ b/docs/pyside/PySide/phonon/Phonon.VolumeFaderEffect.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.VolumeFaderInterface.html
+++ b/docs/pyside/PySide/phonon/Phonon.VolumeFaderInterface.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.VolumeSlider.html
+++ b/docs/pyside/PySide/phonon/Phonon.VolumeSlider.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/Phonon.html
+++ b/docs/pyside/PySide/phonon/Phonon.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/PySide/phonon/index.html
+++ b/docs/pyside/PySide/phonon/index.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/_sources/PySide/QtCore/ClassInfo.txt
+++ b/docs/pyside/_sources/PySide/QtCore/ClassInfo.txt
@@ -17,7 +17,7 @@ Example
 
 ::
 
-    @ClassInfo(Author='PySide Team', URL='http://www.pyside.org')
+    @ClassInfo(Author='PySide Team', URL='https://pyside.github.io')
     class MyObject(QObject):
         ...
 

--- a/docs/pyside/_sources/PySide/QtUiTools/QUiLoader.txt
+++ b/docs/pyside/_sources/PySide/QtUiTools/QUiLoader.txt
@@ -331,7 +331,7 @@ Detailed Description
     of the `.ui` file.
     
     (Remember that `duck punching virtual methods is an invitation for your own demise!
-    <http://www.pyside.org/docs/shiboken/wordsofadvice.html#duck-punching-and-virtual-methods>`_)
+    <https://pyside.github.io/docs/shiboken/wordsofadvice.html#duck-punching-and-virtual-methods>`_)
     
     Let's see an obvious example. If you want to create a new widget it's probable you'll end up
     overriding :class:`~PySide.QtGui.QWidget`'s :meth:`~PySide.QtGui.QWidget.paintEvent` method.

--- a/docs/pyside/_sources/pysideapi2.txt
+++ b/docs/pyside/_sources/pysideapi2.txt
@@ -7,7 +7,7 @@ PySide API 2
 Since the beginning one of the PySide goals was to be API compatible with PyQt4,
 but with some (documented) exceptions. For example, PySide will not export to
 Python components marked as deprecated on C++ Qt. All the modifications follow
-the `PSEP101 <http://www.pyside.org/docs/pseps/psep-0101.html>`_ as its guideline.
+the `PSEP101 <https://pyside.github.io/docs/pseps/psep-0101.html>`_ as its guideline.
 
 The release 4.7 of PyQt4 came with improvements on the pythonic front, being
 the extinction of QString a good example. PySide followed this change, except in

--- a/docs/pyside/contents.html
+++ b/docs/pyside/contents.html
@@ -30,7 +30,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/index.html
+++ b/docs/pyside/index.html
@@ -29,7 +29,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="#">PySide 1.2.1 documentation</a></li> 
@@ -65,7 +65,7 @@
     GUI package, allowing C++ developers to write their applications once and run them unmodified in different systems.
     PySide aims to provide Python developers access to the Qt libraries in the most natural way.</p>
 
-    <p>PySide is built using the <a href="http://www.pyside.org/docs/shiboken">Shiboken</a> binding generator.</p>
+    <p>PySide is built using the <a href="https://pyside.github.io/docs/shiboken">Shiboken</a> binding generator.</p>
 
   <h2>Notes</h2>
 

--- a/docs/pyside/modules.html
+++ b/docs/pyside/modules.html
@@ -31,7 +31,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/py-modindex.html
+++ b/docs/pyside/py-modindex.html
@@ -33,7 +33,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/pysideapi2.html
+++ b/docs/pyside/pysideapi2.html
@@ -31,7 +31,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">PySide 1.2.1 documentation</a></li> 
@@ -85,7 +85,7 @@
 <p>Since the beginning one of the PySide goals was to be API compatible with PyQt4,
 but with some (documented) exceptions. For example, PySide will not export to
 Python components marked as deprecated on C++ Qt. All the modifications follow
-the <a class="reference external" href="http://www.pyside.org/docs/pseps/psep-0101.html">PSEP101</a> as its guideline.</p>
+the <a class="reference external" href="https://pyside.github.io/docs/pseps/psep-0101.html">PSEP101</a> as its guideline.</p>
 <p>The release 4.7 of PyQt4 came with improvements on the pythonic front, being
 the extinction of QString a good example. PySide followed this change, except in
 one point: while PyQt4 has conserved the old behavior as optional, PySide

--- a/docs/pyside/pysideversion.html
+++ b/docs/pyside/pysideversion.html
@@ -30,7 +30,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/search.html
+++ b/docs/pyside/search.html
@@ -37,7 +37,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/tutorials/index.html
+++ b/docs/pyside/tutorials/index.html
@@ -31,7 +31,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../index.html">PySide 1.2.1 documentation</a></li> 

--- a/docs/pyside/tutorials/qmladvancedtutorial/index.html
+++ b/docs/pyside/tutorials/qmladvancedtutorial/index.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/tutorials/qmladvancedtutorial/samegame1.html
+++ b/docs/pyside/tutorials/qmladvancedtutorial/samegame1.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/tutorials/qmladvancedtutorial/samegame2.html
+++ b/docs/pyside/tutorials/qmladvancedtutorial/samegame2.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/tutorials/qmladvancedtutorial/samegame3.html
+++ b/docs/pyside/tutorials/qmladvancedtutorial/samegame3.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/tutorials/qmladvancedtutorial/samegame4.html
+++ b/docs/pyside/tutorials/qmladvancedtutorial/samegame4.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/tutorials/qmltutorial/index.html
+++ b/docs/pyside/tutorials/qmltutorial/index.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/tutorials/qmltutorial/step1.html
+++ b/docs/pyside/tutorials/qmltutorial/step1.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/tutorials/qmltutorial/step2.html
+++ b/docs/pyside/tutorials/qmltutorial/step2.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/pyside/tutorials/qmltutorial/step3.html
+++ b/docs/pyside/tutorials/qmltutorial/step3.html
@@ -32,7 +32,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="../../_static/pysidelogo.png" width="199" height="102" /></a></div>
         <div class="related">
             <ul>
                 <li><a href="../../index.html">PySide 1.2.1 documentation</a></li>

--- a/docs/shiboken/_sources/codeinjectionsemantics.txt
+++ b/docs/shiboken/_sources/codeinjectionsemantics.txt
@@ -3,7 +3,7 @@ Code Injection Semantics
 ************************
 
 API Extractor provides the `inject-code
-<http://www.pyside.org/docs/apiextractor/typesystem_manipulating_objects.html#inject-code>`_ tag
+<https://pyside.github.io/docs/apiextractor/typesystem_manipulating_objects.html#inject-code>`_ tag
 allowing the user to put custom written code to on specific locations of the generated code.
 Yet this is only part of what is needed to generate proper binding code, where the custom code
 should be written to depends upon the technology used on the generated binding code.

--- a/docs/shiboken/_sources/faq.txt
+++ b/docs/shiboken/_sources/faq.txt
@@ -11,7 +11,7 @@ General
 What is Shiboken?
 -----------------
 
-Shiboken is a `GeneratorRunner <http://www.pyside.org/home-binding/binding-generator>`_
+Shiboken is a `GeneratorRunner <https://pyside.github.io/home-binding/binding-generator>`_
 plugin that outputs C++ code for CPython extensions. The first version of PySide
 had source code based on Boost templates. It was easier to produce code but a
 paradigm change was needed, as the next question explains.
@@ -44,7 +44,7 @@ What do I have to do to create my bindings?
 .. todo: put link to typesystem documentation
 
 Most of the work is already done by the API Extractor. The developer creates
-a `typesystem <http://www.pyside.org/docs/apiextractor/typesystem.html>`_ file
+a `typesystem <https://pyside.github.io/docs/apiextractor/typesystem.html>`_ file
 with any customization wanted in the generated code, like removing classes or
 changing method signatures. The generator will output the .h and .cpp files
 with the CPython code that will wrap the target library for python.

--- a/docs/shiboken/_sources/typeconverters.txt
+++ b/docs/shiboken/_sources/typeconverters.txt
@@ -51,24 +51,24 @@ For the user defined conversion code to be inserted in the proper places, the "<
 
 
 The details will be given later, but the gist of it are the tags
-`<native-to-target> <http://www.pyside.org/docs/apiextractor/typesystem_conversionrule.html#native-to-target>`_,
+`<native-to-target> <https://pyside.github.io/docs/apiextractor/typesystem_conversionrule.html#native-to-target>`_,
 which has only one conversion from C++ to Python, and
-`<target-to-native> <http://www.pyside.org/docs/apiextractor/typesystem_conversionrule.html#target-to-native>`_,
+`<target-to-native> <https://pyside.github.io/docs/apiextractor/typesystem_conversionrule.html#target-to-native>`_,
 that may define the conversion of multiple Python types to C++'s "Complex" type.
 
 .. image:: images/converter.png
     :height: 240px
     :align: center
 
-|project| expects the code for `<native-to-target> <http://www.pyside.org/docs/apiextractor/typesystem_conversionrule.html#native-to-target>`_,
+|project| expects the code for `<native-to-target> <https://pyside.github.io/docs/apiextractor/typesystem_conversionrule.html#native-to-target>`_,
 to directly return the Python result of the conversion, and the added conversions inside the
-`<target-to-native> <http://www.pyside.org/docs/apiextractor/typesystem_conversionrule.html#target-to-native>`_
+`<target-to-native> <https://pyside.github.io/docs/apiextractor/typesystem_conversionrule.html#target-to-native>`_
 must attribute the Python to C++ conversion result to the :ref:`%out <out>` variable.
 
 
 Expanding on the last example, if the binding developer want a Python 2-tuple of numbers to be accepted
 by wrapped C++ functions with "Complex" arguments, an
-`<add-conversion> <http://www.pyside.org/docs/apiextractor/typesystem_conversionrule.html#add-conversion>`_
+`<add-conversion> <https://pyside.github.io/docs/apiextractor/typesystem_conversionrule.html#add-conversion>`_
 tag and a custom check must be added. Here's how to do it:
 
       .. code-block:: xml
@@ -127,7 +127,7 @@ Container Conversions
 =====================
 
 Converters for
-`<container-type> <http://www.pyside.org/docs/apiextractor/typesystem_specifying_types.html#container-type>`_
+`<container-type> <https://pyside.github.io/docs/apiextractor/typesystem_specifying_types.html#container-type>`_
 are pretty much the same as for other type, except that they make use of the type system variables
 :ref:`%INTYPE_# <intype_n>` and :ref:`%OUTTYPE_# <outtype_n>`. |project| combines the conversion code for
 containers with the conversion defined (or automatically generated) for the containees.
@@ -283,6 +283,6 @@ In this case, the parts of the implementation that will be used in the new conve
 are the ones in the two last method ``static inline PyObject* toPython(const Complex& cpx)``
 and ``static inline Complex toCpp(PyObject* pyobj)``. The ``isConvertible`` method is gone,
 and the ``checkType`` is now an attribute of the
-`<add-conversion> <http://www.pyside.org/docs/apiextractor/typesystem_conversionrule.html#add-conversion>`_
+`<add-conversion> <https://pyside.github.io/docs/apiextractor/typesystem_conversionrule.html#add-conversion>`_
 tag. Refer back to the first example in this page and you will be able to correlate the above template
 with the new scheme of conversion rule definition.

--- a/docs/shiboken/_sources/typesystemvariables.txt
+++ b/docs/shiboken/_sources/typesystemvariables.txt
@@ -60,7 +60,7 @@ Variables
   the argument so completely that it doesn't appear in any form on the
   ``%ARGUMENT_NAMES`` replacement, don't forget to remove also its default value
   with the `<remove-default-expression/>
-  <http://www.pyside.org/docs/apiextractor/typesystem_arguments.html#remove-default-expression>`_
+  <https://pyside.github.io/docs/apiextractor/typesystem_arguments.html#remove-default-expression>`_
   type system tag.
 
   Take the following method and related type system description as an example:

--- a/docs/shiboken/codeinjectionsemantics.html
+++ b/docs/shiboken/codeinjectionsemantics.html
@@ -31,7 +31,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
   
     <div class="related">
       <h3>Navigation</h3>
@@ -108,7 +108,7 @@
             
   <div class="section" id="code-injection-semantics">
 <h1>7. Code Injection Semantics<a class="headerlink" href="#code-injection-semantics" title="Permalink to this headline">¶</a></h1>
-<p>API Extractor provides the <a class="reference external" href="http://www.pyside.org/docs/apiextractor/typesystem_manipulating_objects.html#inject-code">inject-code</a> tag
+<p>API Extractor provides the <a class="reference external" href="https://pyside.github.io/docs/apiextractor/typesystem_manipulating_objects.html#inject-code">inject-code</a> tag
 allowing the user to put custom written code to on specific locations of the generated code.
 Yet this is only part of what is needed to generate proper binding code, where the custom code
 should be written to depends upon the technology used on the generated binding code.</p>

--- a/docs/shiboken/commandlineoptions.html
+++ b/docs/shiboken/commandlineoptions.html
@@ -31,7 +31,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
   
     <div class="related">
       <h3>Navigation</h3>

--- a/docs/shiboken/contents.html
+++ b/docs/shiboken/contents.html
@@ -30,7 +30,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
   
     <div class="related">
       <h3>Navigation</h3>

--- a/docs/shiboken/faq.html
+++ b/docs/shiboken/faq.html
@@ -31,7 +31,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
   
     <div class="related">
       <h3>Navigation</h3>
@@ -102,7 +102,7 @@ suggest new entries!</p>
 <h2>1.1. General<a class="headerlink" href="#general" title="Permalink to this headline">¶</a></h2>
 <div class="section" id="what-is-shiboken">
 <h3>1.1.1. What is Shiboken?<a class="headerlink" href="#what-is-shiboken" title="Permalink to this headline">¶</a></h3>
-<p>Shiboken is a <a class="reference external" href="http://www.pyside.org/home-binding/binding-generator">GeneratorRunner</a>
+<p>Shiboken is a <a class="reference external" href="https://pyside.github.io/home-binding/binding-generator">GeneratorRunner</a>
 plugin that outputs C++ code for CPython extensions. The first version of PySide
 had source code based on Boost templates. It was easier to produce code but a
 paradigm change was needed, as the next question explains.</p>
@@ -128,7 +128,7 @@ and the C++ library that is being wrapped.</p>
 <div class="section" id="what-do-i-have-to-do-to-create-my-bindings">
 <h3>1.2.3. What do I have to do to create my bindings?<a class="headerlink" href="#what-do-i-have-to-do-to-create-my-bindings" title="Permalink to this headline">¶</a></h3>
 <p>Most of the work is already done by the API Extractor. The developer creates
-a <a class="reference external" href="http://www.pyside.org/docs/apiextractor/typesystem.html">typesystem</a> file
+a <a class="reference external" href="https://pyside.github.io/docs/apiextractor/typesystem.html">typesystem</a> file
 with any customization wanted in the generated code, like removing classes or
 changing method signatures. The generator will output the .h and .cpp files
 with the CPython code that will wrap the target library for python.</p>

--- a/docs/shiboken/index.html
+++ b/docs/shiboken/index.html
@@ -29,7 +29,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
   
     <div class="related">
       <h3>Navigation</h3>

--- a/docs/shiboken/overview.html
+++ b/docs/shiboken/overview.html
@@ -31,7 +31,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
   
     <div class="related">
       <h3>Navigation</h3>

--- a/docs/shiboken/ownership.html
+++ b/docs/shiboken/ownership.html
@@ -31,7 +31,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
   
     <div class="related">
       <h3>Navigation</h3>

--- a/docs/shiboken/projectfile.html
+++ b/docs/shiboken/projectfile.html
@@ -31,7 +31,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
   
     <div class="related">
       <h3>Navigation</h3>

--- a/docs/shiboken/search.html
+++ b/docs/shiboken/search.html
@@ -37,7 +37,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
   
     <div class="related">
       <h3>Navigation</h3>

--- a/docs/shiboken/sequenceprotocol.html
+++ b/docs/shiboken/sequenceprotocol.html
@@ -31,7 +31,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
   
     <div class="related">
       <h3>Navigation</h3>

--- a/docs/shiboken/shibokenmodule.html
+++ b/docs/shiboken/shibokenmodule.html
@@ -30,7 +30,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
   
     <div class="related">
       <h3>Navigation</h3>

--- a/docs/shiboken/typeconverters.html
+++ b/docs/shiboken/typeconverters.html
@@ -31,7 +31,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
   
     <div class="related">
       <h3>Navigation</h3>
@@ -132,18 +132,18 @@
 </div>
 </div></blockquote>
 <p>The details will be given later, but the gist of it are the tags
-<a class="reference external" href="http://www.pyside.org/docs/apiextractor/typesystem_conversionrule.html#native-to-target">&lt;native-to-target&gt;</a>,
+<a class="reference external" href="https://pyside.github.io/docs/apiextractor/typesystem_conversionrule.html#native-to-target">&lt;native-to-target&gt;</a>,
 which has only one conversion from C++ to Python, and
-<a class="reference external" href="http://www.pyside.org/docs/apiextractor/typesystem_conversionrule.html#target-to-native">&lt;target-to-native&gt;</a>,
+<a class="reference external" href="https://pyside.github.io/docs/apiextractor/typesystem_conversionrule.html#target-to-native">&lt;target-to-native&gt;</a>,
 that may define the conversion of multiple Python types to C++&#8217;s &#8220;Complex&#8221; type.</p>
 <a class="reference internal image-reference" href="_images/converter.png"><img alt="_images/converter.png" class="align-center" src="_images/converter.png" style="height: 240px;" /></a>
-<p>Shiboken expects the code for <a class="reference external" href="http://www.pyside.org/docs/apiextractor/typesystem_conversionrule.html#native-to-target">&lt;native-to-target&gt;</a>,
+<p>Shiboken expects the code for <a class="reference external" href="https://pyside.github.io/docs/apiextractor/typesystem_conversionrule.html#native-to-target">&lt;native-to-target&gt;</a>,
 to directly return the Python result of the conversion, and the added conversions inside the
-<a class="reference external" href="http://www.pyside.org/docs/apiextractor/typesystem_conversionrule.html#target-to-native">&lt;target-to-native&gt;</a>
+<a class="reference external" href="https://pyside.github.io/docs/apiextractor/typesystem_conversionrule.html#target-to-native">&lt;target-to-native&gt;</a>
 must attribute the Python to C++ conversion result to the <a class="reference internal" href="#out"><em>%out</em></a> variable.</p>
 <p>Expanding on the last example, if the binding developer want a Python 2-tuple of numbers to be accepted
 by wrapped C++ functions with &#8220;Complex&#8221; arguments, an
-<a class="reference external" href="http://www.pyside.org/docs/apiextractor/typesystem_conversionrule.html#add-conversion">&lt;add-conversion&gt;</a>
+<a class="reference external" href="https://pyside.github.io/docs/apiextractor/typesystem_conversionrule.html#add-conversion">&lt;add-conversion&gt;</a>
 tag and a custom check must be added. Here&#8217;s how to do it:</p>
 <blockquote>
 <div><div class="highlight-xml"><div class="highlight"><pre><span class="c">&lt;!-- Code injection at module level. --&gt;</span>
@@ -197,7 +197,7 @@ static bool Check2TupleOfNumbers(PyObject* pyIn) {
 <div class="section" id="container-conversions">
 <span id="id3"></span><h2>6.1. Container Conversions<a class="headerlink" href="#container-conversions" title="Permalink to this headline">¶</a></h2>
 <p>Converters for
-<a class="reference external" href="http://www.pyside.org/docs/apiextractor/typesystem_specifying_types.html#container-type">&lt;container-type&gt;</a>
+<a class="reference external" href="https://pyside.github.io/docs/apiextractor/typesystem_specifying_types.html#container-type">&lt;container-type&gt;</a>
 are pretty much the same as for other type, except that they make use of the type system variables
 <a class="reference internal" href="#intype-n"><em>%INTYPE_#</em></a> and <a class="reference internal" href="#outtype-n"><em>%OUTTYPE_#</em></a>. Shiboken combines the conversion code for
 containers with the conversion defined (or automatically generated) for the containees.</p>
@@ -313,7 +313,7 @@ to the new scheme.</p>
 are the ones in the two last method <tt class="docutils literal"><span class="pre">static</span> <span class="pre">inline</span> <span class="pre">PyObject*</span> <span class="pre">toPython(const</span> <span class="pre">Complex&amp;</span> <span class="pre">cpx)</span></tt>
 and <tt class="docutils literal"><span class="pre">static</span> <span class="pre">inline</span> <span class="pre">Complex</span> <span class="pre">toCpp(PyObject*</span> <span class="pre">pyobj)</span></tt>. The <tt class="docutils literal"><span class="pre">isConvertible</span></tt> method is gone,
 and the <tt class="docutils literal"><span class="pre">checkType</span></tt> is now an attribute of the
-<a class="reference external" href="http://www.pyside.org/docs/apiextractor/typesystem_conversionrule.html#add-conversion">&lt;add-conversion&gt;</a>
+<a class="reference external" href="https://pyside.github.io/docs/apiextractor/typesystem_conversionrule.html#add-conversion">&lt;add-conversion&gt;</a>
 tag. Refer back to the first example in this page and you will be able to correlate the above template
 with the new scheme of conversion rule definition.</p>
 </div>

--- a/docs/shiboken/typesystemvariables.html
+++ b/docs/shiboken/typesystemvariables.html
@@ -31,7 +31,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
   
     <div class="related">
       <h3>Navigation</h3>
@@ -124,7 +124,7 @@ the removed argument has a default value (original or provided in the type
 system), this value will be inserted in the argument list. If you want to remove
 the argument so completely that it doesn&#8217;t appear in any form on the
 <tt class="docutils literal"><span class="pre">%ARGUMENT_NAMES</span></tt> replacement, don&#8217;t forget to remove also its default value
-with the <a class="reference external" href="http://www.pyside.org/docs/apiextractor/typesystem_arguments.html#remove-default-expression">&lt;remove-default-expression/&gt;</a>
+with the <a class="reference external" href="https://pyside.github.io/docs/apiextractor/typesystem_arguments.html#remove-default-expression">&lt;remove-default-expression/&gt;</a>
 type system tag.</p>
 <p>Take the following method and related type system description as an example:</p>
 <blockquote>

--- a/docs/shiboken/wordsofadvice.html
+++ b/docs/shiboken/wordsofadvice.html
@@ -31,7 +31,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="_static/pysidelogo.png" width="199" height="102" /></a></div>
   
     <div class="related">
       <h3>Navigation</h3>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 <div id="container">
 <div class="header">
     <div class="header_container">
-        <div class="logo"><a href="http://www.pyside.org"><img alt="PySide" src="docs/pyside/_static/pysidelogo.png" width="199" height="102"></a></div>
+        <div class="logo"><a href="https://pyside.github.io"><img alt="PySide" src="docs/pyside/_static/pysidelogo.png" width="199" height="102"></a></div>
         <div class="related">
             <ul>
                 <li><a href="#">PySide documentation</a></li> 


### PR DESCRIPTION
A simple find-replace to point the links to the (now dead) pyside.org to pyside.github.io
